### PR TITLE
Fixing templating docs url.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains all the themes for book landing pages on [gitbook.com](https://www.gitbook.com).
 
-If you want to publish your themes to be usable by all gitbook.com users, feel free to do a Pull-Request. Documentation on templating can be found in the [GitBook's documentation](http://help.gitbook.io/book/themes.html).
+If you want to publish your themes to be usable by all gitbook.com users, feel free to do a Pull-Request. Documentation on templating can be found in the [GitBook's documentation](http://help.gitbook.com/format/templating.html).
 
 ## How to test and publish a theme?
 


### PR DESCRIPTION
The docs url was throwing a 404. It now points to http://help.gitbook.com/format/templating.html.